### PR TITLE
Fixed Bug: SQLite Database File Path Without Directory No Longer Causes Exception in Windows System.

### DIFF
--- a/ebookstore.py
+++ b/ebookstore.py
@@ -48,8 +48,8 @@ def main():
     elif database_file:  # Connect to SQLite database
         # Create the directory(s) if it/they doesn't exist
         try:
-            #if os.path.dirname(database_file): 
-            os.makedirs(os.path.dirname(database_file), exist_ok=True)
+            if os.path.dirname(database_file): 
+                os.makedirs(os.path.dirname(database_file), exist_ok=True)
             book_store = BookStoreSqlite(
                 database_file, args.table_name, table_records
             )


### PR DESCRIPTION
As per issue #7  In the main script, checks the database file path contains a directory, before making the directory if it doesn't exist. The program no longer throws the error in windows system