### PR TITLE
Issue #20 - Improved command to run the application in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,15 @@ eBookstore is a command-line application with a user-friendly interface that all
 1. Running Directly on Your Localhost
    * Run the main script: 
      - `python3 ebookstore.py --database-file "/path_to_database_file"`
-   * For more advanced usage and available command-line arguments, please run:
-     - `python3 ebookstore.py --help`
    * Instructions:
      - Follow the on-screen instructions to interact with the inventory system.
+   * For more advanced usage and available command-line arguments, please run:
+     - `python3 ebookstore.py --help`
 2. Running on Docker Container (Ensure you have root/admin privileges)
    * Run the container:
      - `docker run -i -v path_to_database_file:/data evanchime/ebookstore --database-file "/data/path_to_database_file"`
+   * Instructions:
+     - Follow the on-screen instructions to interact with the inventory system.
    * For more advanced usage and available command-line arguments, please run:
      - `docker run evanchime/ebookstore:latest --help`
 

--- a/README.md
+++ b/README.md
@@ -51,27 +51,16 @@ eBookstore is a command-line application with a user-friendly interface that all
 ## Usage
 1. Running Directly on Your Localhost
    * Run the main script: 
-     - `python3 ebookstore.py [--database-file "/path_to_database_file" | --connection-url "database_connection_string"] [--table-records "predefined_table_records_file"] [--table-name "table_name"]`
-   * Database Options:
-     - The path_to_database_file is for SQlite
-     - The database_connection_string is for MySQL
-   * MySQL Connection String Format:
-     - `mysql://user:password@host:port/database`
-   * Environment Variable:
-     - The database connection string can also be provided in a variable in an environment file with the variable named `MYSQL_CONNECTION_URL`
+     - `python3 ebookstore.py --database-file "/path_to_database_file"`
+   * For more advanced usage and available command-line arguments, please run:
+     - `python3 ebookstore.py --help`
    * Instructions:
      - Follow the on-screen instructions to interact with the inventory system.
 2. Running on Docker Container (Ensure you have root/admin privileges)
-   * Connect to SQLite database
-     - `docker run -i -v path_to_database_file:/data evanchime/ebookstore --database-file "/data/path_to_database_file" [--table-records "/data/path_to_table_records_file"] [--table-name "table_name"]`
-   * Connect to MySQL database from command line
-     - `docker run -i [-v path_to_table_records_file:/data] evanchime/ebookstore --connection-url "database_connection_string" [--table-records "/data/path_to_table_records_file"] [--table-name "table_name"]`
-   * Connect to MySQL database from an environment file
-     - `docker run -i [-v path_to_table_records_file:/data] --env-file path_to_environment_file evanchime/ebookstore [--table-records "/data/path_to_table_records_file"] [--table-name "table_name"]`
-     - You can also use Docker Compose with an environment file
-     - The database connection string in a variable in an environment file should be named `MYSQL_CONNECTION_URL`
-   * MySQL Connection String Format:
-     - `mysql://user:password@host:port/database`
+   * Run the container:
+     - `docker run -i -v path_to_database_file:/data evanchime/ebookstore --database-file "/data/path_to_database_file"`
+   * For more advanced usage and available command-line arguments, please run:
+     - `docker run evanchime/ebookstore:latest --help`
 
 ![First screenshot of ebookstore](ebookstore_screenshot_1.png)
 ![Second continuation screenshot of ebookstore](ebookstore_screenshot_2.png)

--- a/functions.py
+++ b/functions.py
@@ -372,7 +372,12 @@ def parse_cli_args():
         description='Connect to a database and perform operations'
     )
     parser.add_argument(
-        '--connection-url', type=str, help='MySQL connection URL'
+        '--connection-url', 
+        type=str, 
+        help='MySQL connection URL '
+             '(e.g., "mysql://user:password@host/database"). '
+             'Can also be provided via the MYSQL_CONNECTION_URL '
+             'environment variable.'
     )
     parser.add_argument(
         '--database-file', type=str, help='Sqlite database file'

--- a/functions.py
+++ b/functions.py
@@ -374,10 +374,12 @@ def parse_cli_args():
     parser.add_argument(
         '--connection-url', 
         type=str, 
-        help='MySQL connection URL '
-             '(e.g., "mysql://user:password@host/database"). '
-             'Can also be provided via the MYSQL_CONNECTION_URL '
-             'environment variable.'
+        help=(
+            'MySQL connection URL '
+            '(e.g., "mysql://user:password@host:port/database"). '
+            'Can also be provided via the MYSQL_CONNECTION_URL '
+            'environment variable.'
+        )
     )
     parser.add_argument(
         '--database-file', type=str, help='Sqlite database file'

--- a/functions.py
+++ b/functions.py
@@ -375,7 +375,8 @@ def parse_cli_args():
         '--connection-url', 
         type=str, 
         help='MySQL connection URL '
-             '(e.g., "mysql://user:password@host/database"). '
+        help='MySQL connection URL'
+             ' (e.g., "mysql://user:password@host/database"). '
              'Can also be provided via the MYSQL_CONNECTION_URL '
              'environment variable.'
     )


### PR DESCRIPTION
As per #20 the "Usage" section of the README.md have been updated to use a more streamlined example. Provided a clear, minimal localhost command and docker run command that includes only the most essential arguments (like volume mounts and the database file path). Removed the exhaustive list of all possible arguments from this primary example. Directed users to run the container with the --help flag to discover all advanced options.