### PR TITLE
Issue #22 - README updated and v1.0.1 ready for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # eBookstore
 
 [![Publish ebookstore Docker image](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml/badge.svg)](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/evanchime/ebookstore)](https://github.com/evanchime/ebookstore/releases/latest )
 
 Welcome to eBookstore, a Python project for managing a bookstore.
 
@@ -68,16 +69,17 @@ eBookstore is a command-line application with a user-friendly interface that all
 
 ### Stable & Reproducible Docker Usage (Recommended for Production )
 
-For use in scripts, automation, or production environments, we strongly recommend pinning to a specific version tag instead of using `latest`. This ensures you are always running a predictable, stable version of the application.
+For use in scripts or production, we strongly recommend pinning to a specific version tag. This ensures you are always running a predictable, stable version. **Our latest release is shown in the badge at the top of this page.**
 
 There are two main strategies for pinning your version:
 
 **1. Pinning to a Minor Version (e.g., `:v1.0`)**
 
-This approach gives you a balance of stability and automatic security updates. The `:v1.0` tag will always point to the latest patch release within the `1.0.x` series. This is a great choice if you want to receive non-breaking bug fixes automatically.
+This approach gives you a balance of stability and automatic security updates. The `:v1.0` tag will always point to the latest patch release within the `1.0.x` series. 
 
 ```sh
 # This will pull the latest patch for v1.0 (e.g., v1.0.1, then v1.0.2 later)
+# Update the version number to match the latest release badge!
 docker pull evanchime/ebookstore:v1.0
 ```
 
@@ -87,6 +89,7 @@ This is the most stable and reproducible method. The :v1.0.1 tag is an immutable
 
 ```sh
 # This will ALWAYS pull the exact v1.0.1 release and nothing else
+# Update the version number to match the latest release badge!
 docker pull evanchime/ebookstore:v1.0.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ eBookstore is a command-line application with a user-friendly interface that all
    * For more advanced usage and available command-line arguments, please run:
      - `docker run evanchime/ebookstore:latest --help`
 
-### Stable & Reproducible Docker Usage (Recommended for Production )
+### Stable & Reproducible Docker Usage (Recommended for Production)
 
 For use in scripts or production, we strongly recommend pinning to a specific version tag. This ensures you are always running a predictable, stable version. **Our latest release is shown in the badge at the top of this page.**
 

--- a/README.md
+++ b/README.md
@@ -73,24 +73,24 @@ For use in scripts or production, we strongly recommend pinning to a specific ve
 
 There are two main strategies for pinning your version:
 
-**1. Pinning to a Minor Version (e.g., `:v1.0`)**
+**1. Pinning to a Minor Version (e.g., `:vX.X`)**
 
-This approach gives you a balance of stability and automatic security updates. The `:v1.0` tag will always point to the latest patch release within the `1.0.x` series. 
+This approach gives you a balance of stability and automatic security updates. The `:vX.X` tag will always point to the latest patch release within the `X.X.X` series. 
 
 ```sh
-# This will pull the latest patch for v1.0 (e.g., v1.0.1, then v1.0.2 later)
+# This will pull the latest patch for vX.X (e.g., vX.X.1, then vX.X.2 later)
 # Update the version number to match the latest release badge!
-docker pull evanchime/ebookstore:v1.0
+docker pull evanchime/ebookstore:vX.X
 ```
 
-**2. Pinning to a Specific Patch Version (e.g., :v1.0.1)**
+**2. Pinning to a Specific Patch Version (e.g., :vX.X.X)**
 
-This is the most stable and reproducible method. The :v1.0.1 tag is an immutable pointer to a single, specific release and will never change. This is the best choice for critical systems where you must guarantee that the running code is exactly the same every time.
+This is the most stable and reproducible method. The :vX.X.X tag is an immutable pointer to a single, specific release and will never change. This is the best choice for critical systems where you must guarantee that the running code is exactly the same every time.
 
 ```sh
-# This will ALWAYS pull the exact v1.0.1 release and nothing else
+# This will ALWAYS pull the exact vX.X.X release and nothing else
 # Update the version number to match the latest release badge!
-docker pull evanchime/ebookstore:v1.0.1
+docker pull evanchime/ebookstore:vX.X.X
 ```
 
 ![First screenshot of ebookstore](ebookstore_screenshot_1.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eBookstore
 
+[![Publish ebookstore Docker image](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml/badge.svg)](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml)
+
 Welcome to eBookstore, a Python project for managing a bookstore.
 
 ## Table of Contents
@@ -58,11 +60,35 @@ eBookstore is a command-line application with a user-friendly interface that all
      - `python3 ebookstore.py --help`
 2. Running on Docker Container (Ensure you have root/admin privileges)
    * Run the container:
-     - `docker run -i -v path_to_database_file:/data evanchime/ebookstore --database-file "/data/path_to_database_file"`
+     - `docker run -i -v path_to_database_file:/data evanchime/ebookstore:latest --database-file "/data/path_to_database_file"`
    * Instructions:
      - Follow the on-screen instructions to interact with the inventory system.
    * For more advanced usage and available command-line arguments, please run:
      - `docker run evanchime/ebookstore:latest --help`
+
+### Stable & Reproducible Docker Usage (Recommended for Production )
+
+For use in scripts, automation, or production environments, we strongly recommend pinning to a specific version tag instead of using `latest`. This ensures you are always running a predictable, stable version of the application.
+
+There are two main strategies for pinning your version:
+
+**1. Pinning to a Minor Version (e.g., `:v1.0`)**
+
+This approach gives you a balance of stability and automatic security updates. The `:v1.0` tag will always point to the latest patch release within the `1.0.x` series. This is a great choice if you want to receive non-breaking bug fixes automatically.
+
+```sh
+# This will pull the latest patch for v1.0 (e.g., v1.0.1, then v1.0.2 later)
+docker pull evanchime/ebookstore:v1.0
+```
+
+**2. Pinning to a Specific Patch Version (e.g., :v1.0.1)**
+
+This is the most stable and reproducible method. The :v1.0.1 tag is an immutable pointer to a single, specific release and will never change. This is the best choice for critical systems where you must guarantee that the running code is exactly the same every time.
+
+```sh
+# This will ALWAYS pull the exact v1.0.1 release and nothing else
+docker pull evanchime/ebookstore:v1.0.1
+```
 
 ![First screenshot of ebookstore](ebookstore_screenshot_1.png)
 ![Second continuation screenshot of ebookstore](ebookstore_screenshot_2.png)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eBookstore
 
 [![Publish ebookstore Docker image](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml/badge.svg)](https://github.com/evanchime/ebookstore/actions/workflows/publish_ebookstore_docker_image.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/evanchime/ebookstore)](https://github.com/evanchime/ebookstore/releases/latest )
+[![GitHub Release](https://img.shields.io/github/v/release/evanchime/ebookstore)](https://github.com/evanchime/ebookstore/releases/latest)
 
 Welcome to eBookstore, a Python project for managing a bookstore.
 


### PR DESCRIPTION
As per #22 README has been updated with a release badge. Added a "GitHub release" badge to the top of the README.md file to show the latest version number. Updated the example docker pull command to reference a specific version tag (e.g., evanchime/ebookstore:v1.0.1) using placeholders in addition to the latest tag, to encourage reproducible usage. Created a new annotated Git tag v1.0.1 on the main branch.   Pushed the v1.0.1 tag to the remote repository. Created a new GitHub Release from the v1.0.1 tag. Automatically generated release notes summarizing the patches and improvements. This triggered the release workflow. Confirmed that the GitHub Actions workflow ran successfully for the v1.0.1 release. Verified that the evanchime/ebookstore:v1.0.1 and evanchime/ebookstore:v1.0 Docker images were successfully pushed to Docker Hub.